### PR TITLE
Refact/local bind action creators

### DIFF
--- a/dist/revux.js
+++ b/dist/revux.js
@@ -1,8 +1,8 @@
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('redux')) :
-	typeof define === 'function' && define.amd ? define(['exports', 'redux'], factory) :
-	(factory((global.revux = global.revux || {}),global.redux));
-}(this, (function (exports,redux) { 'use strict';
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define(['exports'], factory) :
+	(factory((global.revux = global.revux || {})));
+}(this, (function (exports) { 'use strict';
 
 var Provider = {
   name: 'Provider',
@@ -68,9 +68,39 @@ function shallowEqual(objA, objB) {
   return true;
 }
 
+// Inspired By React-Redux
+// https://github.com/reactjs/redux/blob/master/src/bindActionCreators.js
+
+function bindActionCreators(actionCreators, dispatch) {
+  if (typeof actionCreators === 'function') {
+    return function () {
+      return dispatch(actionCreators.apply(undefined, arguments));
+    };
+  }
+
+  if (typeof actionCreators !== 'object' || actionCreators === null) {
+    throw new Error('[revux] - bindActionCreators expects an object or a function.');
+  }
+
+  var keys = Object.keys(actionCreators);
+  var boundActionCreators = {};
+
+  var _loop = function _loop(key) {
+    var actionCreator = actionCreators[key];
+    if (typeof actionCreator === 'function') boundActionCreators[key] = function () {
+      return dispatch(actionCreator.apply(undefined, arguments));
+    };
+  };
+
+  for (var key in actionCreators) {
+    _loop(key);
+  }
+  return boundActionCreators;
+}
+
 var wrapActionCreators = function wrapActionCreators(actionCreators) {
   return function (dispatch) {
-    return redux.bindActionCreators(actionCreators, dispatch);
+    return bindActionCreators(actionCreators, dispatch);
   };
 };
 

--- a/src/utils/bindActionCreators.js
+++ b/src/utils/bindActionCreators.js
@@ -1,0 +1,22 @@
+// Inspired By React-Redux
+// https://github.com/reactjs/redux/blob/master/src/bindActionCreators.js
+
+export default function bindActionCreators(actionCreators, dispatch) {
+  if (typeof actionCreators === 'function') {
+    return (...args) => dispatch(actionCreators(...args))
+  }
+
+  if (typeof actionCreators !== 'object' || actionCreators === null) {
+    throw new Error('[revux] - bindActionCreators expects an object or a function.')
+  }
+
+  const keys = Object.keys(actionCreators)
+  const boundActionCreators = {}
+  for (let key in actionCreators) {
+    const actionCreator = actionCreators[key];
+    if (typeof actionCreator === 'function')
+      boundActionCreators[key] =  (...args) =>
+        dispatch(actionCreator(...args));
+  }
+  return boundActionCreators
+}

--- a/src/utils/wrapActionCreators.js
+++ b/src/utils/wrapActionCreators.js
@@ -1,6 +1,4 @@
-import {
-  bindActionCreators
-} from 'redux'
+import bindActionCreators from './bindActionCreators'
 
 const wrapActionCreators = (actionCreators) => dispatch => bindActionCreators(actionCreators, dispatch)
 

--- a/test/bindActionCreators.spec.js
+++ b/test/bindActionCreators.spec.js
@@ -1,0 +1,80 @@
+import bindActionCreators from '../src/utils/bindActionCreators';
+import sinon from 'sinon';
+import { expect } from 'chai';
+
+describe('bindActionCreators', () => {
+  let dispatch;
+  beforeEach(() => {
+    dispatch = sinon.spy();
+  });
+  afterEach(() => {
+    dispatch.reset();
+  });
+  describe('When a Function is passed', () => {
+    it('should return an inner function wrapping dispatch and AC', () => {
+      const actionCreator = function (payload) {
+        return {
+          type: 'FAKE_ACTION',
+          payload
+        }
+      }
+
+      const boundedActionCreator = bindActionCreators(actionCreator, dispatch);
+
+      expect(boundedActionCreator).to.be.a('function');
+
+      boundedActionCreator('somepayload');
+      expect(dispatch.calledOnce).to.be.true;
+      expect(dispatch.calledWith({ type: 'FAKE_ACTION', payload: 'somepayload' })).to.be.true;
+    });
+  })
+
+  describe('When an invalid type is provided as action creator', () => {
+    it('should throw an error if an object has been given', () => {
+      const actionCreator = 'actionCreator';
+      expect(() => bindActionCreators(actionCreator, dispatch))
+        .to.throw('[revux] - bindActionCreators expects an object or a function.');
+    });
+  });
+
+  describe('When an Object is passed', () => {
+    it('should return an inner object of wrapping dispatch action creators', () => {
+      const aCs = {
+        login: sinon.stub().returns({ type: 'LOGIN' }),
+        signIn: sinon.stub().returns({ type: 'SIGNIN' })
+      }
+
+      const BoundedACs = bindActionCreators(aCs, dispatch);
+
+      expect(BoundedACs).to.be.an('Object');
+      expect(Object.keys(BoundedACs)).to.deep.equal(Object.keys(aCs));
+
+      for (let actionName in BoundedACs) {
+        BoundedACs[actionName]();
+      }
+
+      expect(dispatch.calledTwice).to.be.true;
+      expect(dispatch.firstCall.calledWith({ type: 'LOGIN' })).to.be.true;
+      expect(dispatch.secondCall.calledWith({ type: 'SIGNIN' })).to.be.true;
+    });
+
+    it('should ignores invalid actionCreator', () => {
+      const aCs = {
+        invalidAction: 'string',
+        validAction: sinon.stub()
+      }
+
+      const BoundedACs = bindActionCreators(aCs, dispatch);
+
+
+      expect(BoundedACs).to.be.an('Object');
+      expect(Object.keys(BoundedACs)).to.deep.equal(['validAction']);
+
+      for (let actionName in BoundedACs) {
+        BoundedACs[actionName]();
+      }
+
+      expect(dispatch.calledOnce).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
There was an unnecessary usage of the whole redux [dependencie](https://github.com/edvincandon/revux/blob/master/src/utils/wrapActionCreators.js) in sources when wrapping action creators. 
Since `bindActionCreators` was the only widget used from redux, changes provided by this request intend to use a local bindActionCreators function instead. Which will thus lead projects importing `revux` to drop *redux* from their dependencies if they are not using it internally. 